### PR TITLE
Fix @mentions at start of sentence and add Laravel 5.7 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "laravel/framework": "5.6.*",
+        "laravel/framework": "5.7.*",
         "xety/configurator": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "xetaio/xetaravel-mentions",
+    "name": "ow/xetaravel-mentions",
     "description": "A package to parse a @mention from a text and mention the user with a notification.",
     "keywords": [
         "laravel",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ow/xetaravel-mentions",
+    "name": "xetaio/xetaravel-mentions",
     "description": "A package to parse a @mention from a text and mention the user with a notification.",
     "keywords": [
         "laravel",

--- a/src/Parser/MentionParser.php
+++ b/src/Parser/MentionParser.php
@@ -29,7 +29,7 @@ class MentionParser extends Configurator
         'regex_replacement' => [
             '{character}' => '@',
             '{pattern}' => '[A-Za-z0-9]',
-            '{rules}' => '{4,20}'
+            '{rules}' => '{1,20}'
         ]
     ];
 
@@ -91,7 +91,7 @@ class MentionParser extends Configurator
 
         $link = $route . $mention;
 
-        return "[{$character}{$mention}]($link)";
+        return " [{$character}{$mention}]($link)";
     }
 
     /**

--- a/src/Parser/MentionParser.php
+++ b/src/Parser/MentionParser.php
@@ -25,11 +25,11 @@ class MentionParser extends Configurator
         'mention' => true,
         'notify' => true,
         'character' => '@',
-        'regex' => '/\s({character}{pattern}{rules})/',
+        'regex' => '/({character}{pattern}{rules})/',
         'regex_replacement' => [
             '{character}' => '@',
             '{pattern}' => '[A-Za-z0-9]',
-            '{rules}' => '{1,20}'
+            '{rules}' => '{4,20}'
         ]
     ];
 

--- a/src/Parser/MentionParser.php
+++ b/src/Parser/MentionParser.php
@@ -91,7 +91,7 @@ class MentionParser extends Configurator
 
         $link = $route . $mention;
 
-        return " [{$character}{$mention}]($link)";
+        return "[{$character}{$mention}]($link)";
     }
 
     /**


### PR DESCRIPTION
I'm not sure if this project is alive or not anymore, but I wanted to use it in a Laravel 5.7 project so this adds:

- Ability to install with Laravel 5.7 (works great, I'm using this in production)
- Fix the regex to work wherever, it shouldn't matter if it's at the start of a sentence